### PR TITLE
Updates documentation with grant information and sets more reasonable defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,6 @@ The Moonbeam Foundation has generously awarded a grant to the Moonwell Artemis c
 The Moonbeam Foundation has generously awarded a grant to the Moonwell Apollo community with the following details:
 - 9,926 MOVR remaining - this should cover 3/23/2023 to 4/20/2023
 - Last updated 02-2023 to award 9,926 MOVR from 2/23/2023 - 3/23/2023
-- Additional 19,852 MOVR to be sent by Moonbeam Foundation in the future - to cover 4/20-5/18 and 5/18-6/15 
+- Additional 19,852 MOVR to be sent by Moonbeam Foundation in the future - to cover 4/20-5/18 and 5/18-6/15
 
-When submitting a reward speed proposal for governance, please create a pull request that updates this file to include information about how much grant funds have been awarded, so that future proposal creators will know how much grant funding there is remaining and how much they can safely award without creating reward indexes that are not able to be delivered by the protocol.
+When submitting a reward speed proposal for governance, please update the [Grants Project](https://github.com/orgs/moonwell-fi/projects/2/views/1) and mark the grant as reduced by the amount awarded.

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -34,6 +34,9 @@ const defaultConfig: DefaultConfig = {
 
         // The default grant sizes, denominated in underlying tokens as whole numbers (no mantissa)
         defaultGrantAmounts: {
+            // 50% of MFAM supply or 500M MFAM emitted over 2 years since 2/23/2022
+            // ~186,912,704 MFAM remaining to be emitted as of 3/14/2023
+            // There are 48 weeks remaining in the 2nd year from 2/23/2023 to 2/23/2024
             [REWARD_TYPE.GOV_TOKEN]: new BigNumber(186_912_704) // 186,912,704 in total remaining
                                             .div(48) // 48 weeks left in the year
                                             .times(4) // 4 weeks per reward cycle


### PR DESCRIPTION
This pull request:
- Updates `README.md` with grant information and instructions on how pending grants should be awarded.
- Sets defaults to fully distribute MFAM over the remaining 48 weeks in the emission schedule
- Normalizes Moonriver and Moonbeam to have the same default rewards, with 100% going to suppliers and 0% to borrowers