### PR TITLE
Adds DEX reward end timestamp to output

### DIFF
--- a/cmd/generate-proposal.ts
+++ b/cmd/generate-proposal.ts
@@ -80,6 +80,7 @@ async function doSanityChecks(mipData: any, options: OptionValues){
 async function getDexCalcs(mipConfig: any, govTokenAmountToEmit: number) {
     const dexSplitPercentage = mipConfig.responses.componentSplits[COMPONENT.DEX_REWARDER]
     const dexTokensToEmit = new BigNumber(govTokenAmountToEmit).times(dexSplitPercentage)
+    const currentEndTime = mipConfig.dexInfo.currentPoolRewardInfo.endTimestamp
 
     const newDEXEmissionsPerSecond = dexTokensToEmit.dividedBy(ONE_DAY_IN_SECONDS * mipConfig.config.daysPerRewardCycle)
     const newDEXEmissionsPerYear = newDEXEmissionsPerSecond.times(ONE_DAY_IN_SECONDS).times(ONE_YEAR_IN_DAYS)
@@ -92,6 +93,7 @@ async function getDexCalcs(mipConfig: any, govTokenAmountToEmit: number) {
         .div(mipConfig.dexInfo.emissionsPerYear)
         .minus(1)
         .times(100)
+    const newDEXEndTimestamp = currentEndTime + (ONE_DAY_IN_SECONDS * mipConfig.config.daysPerRewardCycle)
 
     let dexRewarderChangedPercentString
     if (dexRewarderChangedPercent.integerValue().isGreaterThan(0)){
@@ -106,6 +108,7 @@ async function getDexCalcs(mipConfig: any, govTokenAmountToEmit: number) {
         dexTokensToEmit,
         newDEXEmissionsPerSecond,
         newDEXEmissionAPR,
+        newDEXEndTimestamp,
         dexRewarderChangedPercentString,
         dexRewarderChangedPercent
     }
@@ -506,7 +509,7 @@ async function generateProposalJSON(mipConfig: MipConfig, smCalcs: any, dexCalcs
     await addProposalToPropData(dexRewarder, 'addRewardInfo',
         [
             config.dexPoolID,
-            currentEndTime + (ONE_DAY_IN_SECONDS * mipConfig.config.daysPerRewardCycle),
+            dexCalcs.newDEXEndTimestamp,
             EthersBigNumber.from(
                 dexRewarderSendParam
                     .div(mipConfig.config.daysPerRewardCycle)

--- a/src/templates/cli/dex-rewarder.md.ejs
+++ b/src/templates/cli/dex-rewarder.md.ejs
@@ -3,7 +3,8 @@
     DEX <%= config.nativeTokenName %> Side: <%= chalk.yellowBright(formatNumber(dexInfo.nativeAssetTotal, 0)) %>
     TVL: <%= chalk.yellowBright("$" + formatNumber(dexInfo.poolTVL)) %>
     Dex: <%= chalk.yellowBright(config.dexName) %>
-    Current Reward Expire: <%= chalk.yellowBright(new Date(dexInfo.currentPoolRewardInfo.endTimestamp * 1000).toUTCString()) %>
+    Current Rewards Expire: <%= chalk.yellowBright(new Date(dexInfo.currentPoolRewardInfo.endTimestamp * 1000).toUTCString()) %>
+    Proposed Rewards Expire: <%= chalk.yellowBright(new Date(dexCalcs.newDEXEndTimestamp * 1000).toUTCString()) %>
 
     Total tokens to emit: <%= chalk.yellowBright(formatNumber(dexCalcs.dexTokensToEmit, 0)) %> <%= chalk.yellowBright(config.govTokenName) %> over <%= chalk.yellowBright(config.daysPerRewardCycle) %> days
     Emissions Change: <%=

--- a/src/templates/markdown/dex-rewarder.md.ejs
+++ b/src/templates/markdown/dex-rewarder.md.ejs
@@ -5,6 +5,8 @@ This proposal, if executed, would adjust the rewards on the **Dex Rewarder** <%=
 
 Current rewards will expire at **<%= new Date(dexInfo.currentPoolRewardInfo.endTimestamp * 1000).toUTCString() %>**
 
+Proposed rewards will expire at **<%= new Date(dexCalcs.newDEXEndTimestamp * 1000).toUTCString() %>**
+
 - Current (estimated APR = `~<%= formatNumber(dexInfo.currentPoolAPR, 2) %>%`) days: <%= govRewardSpeeds(config, new BigNumber(dexInfo.currentPoolRewardInfo.rewardPerSec)) %>
 <br><br>
 - Proposed (estimated APR = `~<%= formatNumber(dexCalcs.newDEXEmissionAPR, 2) %>%`): <%= govRewardSpeeds(config, dexCalcs.newDEXEmissionsPerSecond) %>


### PR DESCRIPTION
This PR does the following:
- Adds `dexCalcs.newDEXEndTimestamp` which is calculated in `getDexCalcs` by adding `config.daysPerRewardCycle` in seconds to `dexInfo.currentPoolRewardInfo.endTimestamp`
- Changes `generateProposalJSON` to use `dexCalcs.newDEXEndTimestamp` instead of re-calcluating this timestamp
- Updates both the CLI and Markdown template to print this new end timestamp for easier human verification