### PR TITLE
Updates default grant submission grant on Moonbeam

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
       },
       "bin": {
         "moonwell-config-generator": "dist/cmd/generate-config.js",
-        "moonwell-proposal-generator": "dist/cmd/generate-proposal.js"
+        "moonwell-proposal-generator": "dist/cmd/generate-proposal.js",
+        "moonwell-proposal-viewer": "dist/cmd/view-proposal.js"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.191",

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -70,7 +70,7 @@ const defaultConfig: DefaultConfig = {
 
         dexPoolID: 15,
 
-        submissionRewardAmount: 100_000,
+        submissionRewardAmount: 10_000,
 
         // The default percentage splits, should be in decimal (ex 30% would be 0.3)
         defaultSplits: {


### PR DESCRIPTION
Updates `submissionRewardAmount` to `10_000` instead of `100_000` for the Moonbeam network.